### PR TITLE
Make plugin compatible with other plugin managers

### DIFF
--- a/zsh-toolbox.plugin.zsh
+++ b/zsh-toolbox.plugin.zsh
@@ -1,4 +1,6 @@
-source ~/.oh-my-zsh/plugins/zsh-toolbox/config.zsh
+# Make this work with other plugin managers, not just oh-my-zsh
+source $(dirname "$0")/config.zsh
+
 if [ $zt_welcome = "1" ]; then
   echo "this is zsh, version  $ZSH_VERSION, on"
   uname -v


### PR DESCRIPTION
I'd like to add this to [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins), but as written, it will only work with oh-my-zsh because this line in the plugin file assumes the plugin is in the stock oh-my-zsh plugin location. 

`source ~/.oh-my-zsh/plugins/zsh-toolbox/config.zsh`

It also won't work if someone moves their oh-my-zsh directory.