### PR TITLE
Minor markdown cleanups in `readme.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,22 @@
-#usability
-You can for now: see the welcome message, and there's alias mz to omz
-Now, in version 0.2) you see your ZSH version, as well as uname, and plugin's version
-homebrew packages will update automaticaly if you set it to do so, exclusive for 3.0
-##configuring
-zt_welcome, 0, 1, yes, no, shows welcome message.
-zt_aliases, 0, 1, yes, no, turns on or off the aliases
-zt_brew update homebrew packages automaticaly.
-##contributions
-You can contribute, but remember to ask if the feature will be usefull.
+# zsh-toolbox
+
+## Usability
+
+- You can for now: see the welcome message, and there's alias `mz` to `omz`
+- Now, in version 0.2 you see your ZSH version, as well as uname, and plugin's version
+- homebrew packages will update automaticaly if you set it to do so, exclusive for 3.0
+
+## Configuring
+
+- `zt_welcome 0, 1, yes, no` shows welcome message.
+- `zt_aliases 0, 1, yes, no` turns on or off the aliases
+- `zt_brew` update homebrew packages automaticaly.
+
+## Contributions
+
+You can contribute, but remember to ask if the feature will be useful.
 I am trying to add this plugin to zsh's repo to install it by default.
-##credits
-@unixorn, great trick with source command,.
+
+## Credits
+
+@unixorn, great trick with source command.

--- a/readme.md
+++ b/readme.md
@@ -3,19 +3,19 @@
 ## Usability
 
 - You can for now: see the welcome message, and there's alias `mz` to `omz`
-- Now, in version 0.2 you see your ZSH version, as well as uname, and plugin's version
-- homebrew packages will update automaticaly if you set it to do so, exclusive for 3.0
+- Now, in version 0.2 you see your ZSH version, the output of `uname` and the plugin's version
+- [homebrew](https://brew.sh) packages will update automaticaly if you set it to do so, exclusive for 3.0
 
 ## Configuring
 
-- `zt_welcome 0, 1, yes, no` shows welcome message.
-- `zt_aliases 0, 1, yes, no` turns on or off the aliases
-- `zt_brew` update homebrew packages automaticaly.
+- `zt_welcome 0, 1, yes, no` - Sets display of welcome message.
+- `zt_aliases 0, 1, yes, no` - Turns on or off loading the plugin's aliases
+- `zt_brew` - Update [homebrew](https://brew.sh) packages automaticaly.
 
 ## Contributions
 
 You can contribute, but remember to ask if the feature will be useful.
-I am trying to add this plugin to zsh's repo to install it by default.
+I am trying to add this plugin to ZSH's repo to install it by default.
 
 ## Credits
 


### PR DESCRIPTION
`readme.md` was confusing the github markdown parser and rendering as a blob of text